### PR TITLE
fix: markdown dark mode note tip

### DIFF
--- a/src/styles/markdown.scss
+++ b/src/styles/markdown.scss
@@ -105,7 +105,7 @@
     .mdx-thead, .mdx-tbody .mdx-tr:not(:last-child) { @apply border-b border-slate-600/20; }
   }
 
-  .note {
+  .admonition {
     @apply bg-slate-600/20;
     &::before { @apply bg-zinc-900; }
   }


### PR DESCRIPTION
Fix markdown note tip style in dark mode